### PR TITLE
permit theming by caller

### DIFF
--- a/src/components/license/License.js
+++ b/src/components/license/License.js
@@ -8,8 +8,7 @@ import {makeStyles} from '@material-ui/core/styles';
 export const License = ({
   rights,
   licenseLink,
-  style,
-  iconProps,
+  ...iconProps
 }) => {
 
   const classes = useStyles();
@@ -17,13 +16,8 @@ export const License = ({
   const onClickLicense = () => { openLink(licenseLink); }
 
   let _iconProps = {
-    color: "primary",
-    fontSize: "small",
     onClick: onClickLicense,
-    style: {
-      fontSize: '1em'
-    },
-    ...iconProps,
+    ...iconProps
   };
 
   let rightsIcon = <Tooltip title={rights} arrow><InfoOutlinedIcon {..._iconProps} /></Tooltip> ; 

--- a/src/components/parallel-scripture/ParallelScripture.js
+++ b/src/components/parallel-scripture/ParallelScripture.js
@@ -41,7 +41,7 @@ function ParallelScripture({
             'LICENSE.md'
           ;
           
-          let rightsIcon = <License rights={rights} licenseLink={licenseLink} />
+          let rightsIcon = <License rights={rights} licenseLink={licenseLink} style={{fontSize: "1em", marginLeft: "0.1em"}} />
 
           _title = (
             <Typography variant='caption'>


### PR DESCRIPTION
With this change, the caller can now provide theming/styling for the license info icon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/17)
<!-- Reviewable:end -->
