### PR TITLE
stop propagation of click event issue 172

### DIFF
--- a/src/components/license/License.js
+++ b/src/components/license/License.js
@@ -13,8 +13,8 @@ export const License = ({
 
   const classes = useStyles();
   const openLink = useCallback((link) => window.open(link, '_blank'), []);
-  const onClickLicense = () => { openLink(licenseLink); }
-
+  const onClickLicense = (e) => { e.stopPropagation(); openLink(licenseLink); }
+  
   let _iconProps = {
     onClick: onClickLicense,
     ...iconProps


### PR DESCRIPTION
When pop ups are allowed, this bug will propagate the click event to the parent chip object, which opens the article.

By stopping propagation, the parent chip will not receive the click event even if pop ups are allowed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/36)
<!-- Reviewable:end -->
