### PR TITLE
Bugfix/fix for crash when resource is not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/src/components/resources/useRsrc.js
+++ b/src/components/resources/useRsrc.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import deepFreeze from 'deep-freeze';
 import useEffect from 'use-deep-compare-effect';
@@ -12,6 +12,7 @@ function useRsrc({
   const [bibleJson, setBibleJson] = useState(null);
   const [resource, setResource] = useState({});
   const [content, setContent] = useState(null);
+  const resource_ = resource || {}; // TRICKY - prevents crash in recent `use-deep-compare-effect` module when resource is not found
 
   useEffect(() => {
     resourceFromResourceLink({
@@ -26,8 +27,8 @@ function useRsrc({
 
   useEffect(() => {
     async function getFile() {
-      let file = await resource.project?.file();
-      const isTSV = resource?.project?.path.includes('.tsv');
+      let file = await resource_.project?.file();
+      const isTSV = resource_.project?.path.includes('.tsv');
 
       if (isTSV) {
         file = tsvToJson(file);
@@ -37,13 +38,13 @@ function useRsrc({
     }
 
     getFile();
-  }, [config, resource]);
+  }, [config, resource_]);
 
   useEffect(() => {
-    if (resource && resource.project && options.getBibleJson) {
+    if (resource_ && resource_.project && options.getBibleJson) {
       const parseUsfm = async () => {
         const { chapter, verse } = reference;
-        const { project } = resource;
+        const { project } = resource_;
         const bibleJson = await project.parseUsfm();
 
         if (chapter) {
@@ -63,7 +64,7 @@ function useRsrc({
 
       parseUsfm().then(setBibleJson);
     }
-  }, [options.getBibleJson, resource]);
+  }, [options.getBibleJson, resource_]);
 
   return {
     state: {


### PR DESCRIPTION
- associated with issue: https://github.com/unfoldingword/single-scripture-rcl/issues/6
- can test with can test with https://deploy-preview-51--create-app.netlify.app/
- fix for crash in recent `use-deep-compare-effect` module when resource is not found use ru language and book mat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/81)
<!-- Reviewable:end -->
