### PR TITLE
Bugfix/Scripture Navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.1.1",
+  "version": "3.1.1-alpha",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.1.0",
+  "version": "3.2.0-alpha",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.1.1-alpha",
+  "version": "3.0.5",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.2.0-alpha",
+  "version": "3.2.0",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.0.5-alpha.2",
+  "version": "3.1.0",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "3.0.5",
+  "version": "3.0.5-alpha.2",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/src/components/parallel-scripture/helpers.js
+++ b/src/components/parallel-scripture/helpers.js
@@ -19,7 +19,10 @@ export const referenceIdsFromBooks = ({ books }) => {
 };
 
 export const isVerseKeyInRange = (({ range, verseKey }) => {
-  const [first, last] = range.split('-');
+  verseKey = (typeof verseKey === 'string') ? parseInt(verseKey) : verseKey;
+  let [first, last] = range.split('-');
+  first = parseInt(first);
+  last = parseInt(last);
   const inRange = first <= verseKey && verseKey <= last;
   return inRange;
 });

--- a/src/components/parallel-scripture/helpers.js
+++ b/src/components/parallel-scripture/helpers.js
@@ -28,16 +28,11 @@ export const isVerseKeyInRange = (({ range, verseKey }) => {
 });
 
 export const rangeFromVerseAndVerseKeys = (({ verseKeys, verseKey }) => {
-  let range;
-
-  verseKeys.forEach(_verseKey => {
+  const range = verseKeys.find(_verseKey => {
     if (_verseKey.includes('-')) { // if the verseKey includes - it is a range
-      const inRange = isVerseKeyInRange({ range: _verseKey, verseKey });
-
-      if (inRange) {
-        range = _verseKey;
-      }
-    };
+      return isVerseKeyInRange({ range: _verseKey, verseKey });
+    }
+    return false;
   });
   return range;
 });

--- a/src/components/resources/useRsrc.js
+++ b/src/components/resources/useRsrc.js
@@ -80,7 +80,7 @@ function useRsrc({
 
       parseUsfm().then(setBibleJson);
     }
-  }, [options.getBibleJson, resource_, reference]);
+  }, [options.getBibleJson, resource_]);
 
   return {
     state: {

--- a/src/components/resources/useRsrc.js
+++ b/src/components/resources/useRsrc.js
@@ -10,8 +10,8 @@ import { rangeFromVerseAndVerseKeys } from '../parallel-scripture/helpers';
 function useRsrc({
   config, reference, resourceLink, options = {},
 }) {
-  const [bibleJson, setBibleJson] = useState(null);
-  const [matchedVerse, setMatchedVerse] = useState(null);
+  const [bibleRef, setBibleRef] = useState({});
+  const { bibleJson, matchedVerse } = bibleRef;
   const [resource, setResource] = useState({});
   const [content, setContent] = useState(null);
   const resource_ = resource || {}; // TRICKY - prevents crash in recent `use-deep-compare-effect` module when resource is not found
@@ -55,30 +55,31 @@ function useRsrc({
 
             if (verse) {
               let verseJson = chapterJson[verse];
+              let matchedVerse;
 
               if (!verseJson) { // if verse not found, check verse spans
                 const verseKey = rangeFromVerseAndVerseKeys({ verseKeys: Object.keys(chapterJson), verseKey:verse });
-                setMatchedVerse(verseKey);
 
                 if (verseKey) {
                   verseJson = chapterJson[verseKey];
                 }
+                matchedVerse = verseKey;
               } else {
-                setMatchedVerse(verse);
+                matchedVerse = verse;
               }
-              return verseJson;
+              return { bibleJson: verseJson, matchedVerse };
             } else {
-              return chapterJson;
+              return { bibleJson: chapterJson };
             }
           } catch (e) {
-            return null; // return null if chapter or verse missing
+            return { bibleJson: null }; // return null if chapter or verse missing
           }
         } else {
-          return bibleJson;
+          return { bibleJson };
         }
       };
 
-      parseUsfm().then(setBibleJson);
+      parseUsfm().then(setBibleRef);
     }
   }, [options.getBibleJson, resource_]);
 

--- a/src/components/resources/useRsrc.js
+++ b/src/components/resources/useRsrc.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import deepFreeze from 'deep-freeze';
 import useEffect from 'use-deep-compare-effect';
@@ -12,6 +12,7 @@ function useRsrc({
   const [bibleJson, setBibleJson] = useState(null);
   const [resource, setResource] = useState({});
   const [content, setContent] = useState(null);
+  const resource_ = resource || {}; // TRICKY - prevents crash in recent `use-deep-compare-effect` module when resource is not found
 
   useEffect(() => {
     resourceFromResourceLink({
@@ -26,8 +27,8 @@ function useRsrc({
 
   useEffect(() => {
     async function getFile() {
-      let file = await resource.project?.file();
-      const isTSV = resource?.project?.path.includes('.tsv');
+      let file = await resource_.project?.file();
+      const isTSV = resource_.project?.path.includes('.tsv');
 
       if (isTSV) {
         file = tsvToJson(file);
@@ -37,13 +38,13 @@ function useRsrc({
     }
 
     getFile();
-  }, [config, resource]);
+  }, [config, resource_]);
 
   useEffect(() => {
-    if (resource && resource.project && options.getBibleJson) {
+    if (resource_ && resource_.project && options.getBibleJson) {
       const parseUsfm = async () => {
         const { chapter, verse } = reference;
-        const { project } = resource;
+        const { project } = resource_;
         const bibleJson = await project.parseUsfm();
 
         if (chapter) {
@@ -63,7 +64,7 @@ function useRsrc({
 
       parseUsfm().then(setBibleJson);
     }
-  }, [options.getBibleJson, resource]);
+  }, [options.getBibleJson, resource_]);
 
   return {
     state: {


### PR DESCRIPTION
## Describe what your pull request addresses
- associated with issues: https://github.com/unfoldingword/single-scripture-rcl/issues/6 & https://github.com/unfoldingword/single-scripture-rcl/issues/5
- can test with can test with https://deploy-preview-55--create-app.netlify.app/
- fix for crash in `use-deep-compare-effect` module when resource is not found (and set to null or undefined)
- fix for verse range support

## Testing:
- [ ] can test for verse range support: in ust, select en and go to act 1:24 -  should see verse text for 24 and 25 (displayed verse reference for span will be fixed in later PR).  Then change to vs 25 and should see same text)
- [ ] to test for crash, set one of the panes to use `https://git.door43.org/ru_gl/ru_rsob`, when you select untranslated book like `mat`, should not see a crash (only blank text for now).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/82)
<!-- Reviewable:end -->
