### PR TITLE
Bug cn 469a hightlighting ugnt

### DIFF
--- a/src/components/verse-objects/AlignedWordsObject.js
+++ b/src/components/verse-objects/AlignedWordsObject.js
@@ -19,7 +19,6 @@ function AlignedWordsObject({ children, originalWords, disableWordPopover }) {
     setAnchorEl(null);
   };
 
-  let onClick = () => {};
 
   let selected;
 
@@ -31,22 +30,12 @@ function AlignedWordsObject({ children, originalWords, disableWordPopover }) {
       actions: { areSelected, addSelections, removeSelections },
     } = _selectionsContext;
     selected = areSelected(originalWords);
-    /*
-    onClick = () => {
-      if (selected) {
-        removeSelections(originalWords);
-      } else {
-        addSelections(originalWords);
-      }
-    };
-    */
   }
 
   const words = children.map((verseObject, index) => (
     <span
       data-test="aligned-word-object"
       data-testselected={selected}
-      onClick={onClick}
       key={index}
       className={selected ? classes.selected : undefined}
     >

--- a/src/components/verse-objects/AlignedWordsObject.js
+++ b/src/components/verse-objects/AlignedWordsObject.js
@@ -31,6 +31,7 @@ function AlignedWordsObject({ children, originalWords, disableWordPopover }) {
       actions: { areSelected, addSelections, removeSelections },
     } = _selectionsContext;
     selected = areSelected(originalWords);
+    /*
     onClick = () => {
       if (selected) {
         removeSelections(originalWords);
@@ -38,6 +39,7 @@ function AlignedWordsObject({ children, originalWords, disableWordPopover }) {
         addSelections(originalWords);
       }
     };
+    */
   }
 
   const words = children.map((verseObject, index) => (


### PR DESCRIPTION
This removes a non-function onClick that caused the bug noted in issue 469.

This branch has the letter "a" after the issue number to indicate this was the second attempt at solving the bug and I did not want to prematurely lose what I had done in the first attempt.

@mannycolon I will ask @ancientTexts-net to review this PR, but I think this RCL has also been updated for create 2.0 reasons. When we publish to NPM do we publish in the 2.x major number or in the 3.x?

When I made this change I'm sure I started with the current master - that means I'm updating 3.x, right? Maybe this answers the question... ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/83)
<!-- Reviewable:end -->
