### PR TITLE
Feature 130/Improve network connection checking for translation helps error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.1.7",
+  "version": "4.1.8-alpha",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.1.8-alpha.2",
+  "version": "4.1.8",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.1.8-alpha",
+  "version": "4.1.8-alpha.2",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/src/components/resources/useRsrc.js
+++ b/src/components/resources/useRsrc.js
@@ -53,7 +53,7 @@ function useRsrc({
       setLoadingContent(null); // done
     }
 
-    // if resource loaded then get file only if we are not fetching bible json data
+    // if resource loaded, then get file only if we are not fetching bible json data
     if (Object.keys(resource).length && !options.getBibleJson) {
       getFile();
     }

--- a/src/components/resources/useRsrc.js
+++ b/src/components/resources/useRsrc.js
@@ -53,7 +53,8 @@ function useRsrc({
       setLoadingContent(null); // done
     }
 
-    if (!options.getBibleJson) { // get file only if we are not fetching bible json data
+    // if resource loaded then get file only if we are not fetching bible json data
+    if (Object.keys(resource).length && !options.getBibleJson) {
       getFile();
     }
   }, [config, resource]);


### PR DESCRIPTION
## Describe what your pull request addresses
- part of issue: https://github.com/unfoldingword/gateway-edit/issues/130
- [ ] fixed glitch that would try to fetch file before resource was loaded

## Test Instructions
- note that there are differences in network behavior among browsers.  Firefox may show long delays before showing the network error, but chrome is often immediate.
- test with https://deploy-preview-207--gateway-edit.netlify.app/
- test network error handling while loading trans helps repos:
  - [ ] set org to `test_org`, and `en`, set to tit 1:4, all panes should be showing content
  - [ ] change language to `ru` (should see everything but tQ since it is not in tsv)
  - test network connection error when loading another book:
    - [ ] disconnect from network and change book to `jon`, 
    - [ ] after delay should see popup of network connection error

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118982872-d7405200-b949-11eb-8f12-4d27d2fa65ff.png">

    - [ ] reconnect to network and click cancel
    - [ ] screens should load, but should see this because there are bad characters in support reference, but since network is connected should not see network disconnected popup:

    <img width="1205" alt="Screen Shot 2021-05-20 at 8 45 45 AM" src="https://user-images.githubusercontent.com/14238574/118981405-4d43b980-b948-11eb-8ad2-631b6f200c40.png">  

  - [ ] change tN to 2 of 5 and tA article should load
- testing network error handling loading helps articles
  - [ ] you should still be at jon 1:1. Disconnect from network
  - [ ] change vs to 17 and after long pause should eventually see network error:

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118982872-d7405200-b949-11eb-8f12-4d27d2fa65ff.png">

  - [ ] reconnect to network and click retry.  Page should reload

- test network error handling while clicking links:
  - [ ] change ref to `tit 1:3`, change tN to 2 of 6.
  - [ ] disconnect from network and click this link on tA:

  <img width="707" alt="Screen Shot 2021-05-20 at 9 08 53 AM" src="https://user-images.githubusercontent.com/14238574/118986970-ce517f80-b94d-11eb-86c5-7878c4111f76.png">

  - [ ] after a delay, should see a network error popup

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118987087-efb26b80-b94d-11eb-8918-047453946924.png">

  - [ ] reconnect network, click cancel
  - [ ] change ref to `tit 1:3`, change tN to 2 of 6.
  - [ ] click tA link again and it should load this time


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/107)
<!-- Reviewable:end -->
