### PR TITLE
Feature/add branch and tag support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.3.0-alpha",
+  "version": "4.3.0-alpha.2",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.3.0-alpha.3",
+  "version": "5.0.0",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.2.0",
+  "version": "4.3.0-alpha",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.3.0",
+  "version": "4.3.0-alpha.3",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "4.3.0-alpha.2",
+  "version": "4.3.0",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/src/components/parallel-scripture/ParallelScripture.spec.js
+++ b/src/components/parallel-scripture/ParallelScripture.spec.js
@@ -116,7 +116,7 @@ const [resources, setResources] = React.useState([]);
 </ResourcesContextProvider>;
 
 
-describe('ParallelScripture: resourceFromResourceLink: parse and download resource parallel', () => {
+describe('ParallelScripture: resourceFromResourceLink: parse and download resource', () => {
     it('should be RLOB 2jn', async () => {
         const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
         let content = await resourceFromResourceLink({ resourceLink, reference2jn, config });

--- a/src/components/parallel-scripture/ParallelScripture.spec.js
+++ b/src/components/parallel-scripture/ParallelScripture.spec.js
@@ -116,7 +116,7 @@ const [resources, setResources] = React.useState([]);
 </ResourcesContextProvider>;
 
 
-describe('parse and download resource', () => {
+describe('parse and download resource parallel', () => {
     it('should be RLOB 2jn', async () => {
         const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
         let content = await resourceFromResourceLink({ resourceLink, reference2jn, config });

--- a/src/components/parallel-scripture/ParallelScripture.spec.js
+++ b/src/components/parallel-scripture/ParallelScripture.spec.js
@@ -116,7 +116,7 @@ const [resources, setResources] = React.useState([]);
 </ResourcesContextProvider>;
 
 
-describe('parse and download resource parallel', () => {
+describe('ParallelScripture: resourceFromResourceLink: parse and download resource parallel', () => {
     it('should be RLOB 2jn', async () => {
         const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
         let content = await resourceFromResourceLink({ resourceLink, reference2jn, config });

--- a/src/core/resources.js
+++ b/src/core/resources.js
@@ -180,6 +180,7 @@ export const getResourceProjectFile = async ({
   username,
   languageId,
   resourceId,
+  ref,
   tag,
   project: { path: projectPath },
   config,
@@ -193,6 +194,7 @@ export const getResourceProjectFile = async ({
     username,
     repository,
     path: projectPath,
+    ref,
     tag,
     config,
     fullResponse: true,
@@ -324,7 +326,6 @@ export const getFile = async ({
 
   try {
     const _config = { ...config }; // prevents gitea-react-toolkit from modifying object
-    console.log(`getFile - get url: ${url}, config:`, _config);
     const response = await get({
       url,
       config: _config,

--- a/src/core/resources.js
+++ b/src/core/resources.js
@@ -81,8 +81,10 @@ export const parseResourceLink = ({
     languageId,
     resourceId,
     projectId = reference.projectId || reference.bookId,
-    ref = 'master',
+    tag,
+    ref,
     matched;
+  ref = ref || tag || 'master'; // fallback to using tag if ref not given
   const versionHttpMatch = /https?:\/\/.*org\/api\/v1\/repos\/([^/]*)\/([^/]*)\/([^/]*)([/][^/]*)*\?ref=([^/]+)/;
   const versionLinkMatch = /\/api\/v1\/repos\/([^/]*)\/([^/]*)\/([^/]*)([/][^/]*)*\?ref=([^/]+)/;
 
@@ -145,6 +147,7 @@ export const parseResourceLink = ({
     repository,
     languageId,
     resourceId,
+    tag: ref,
     ref,
     projectId,
     config,
@@ -155,11 +158,13 @@ export const getResourceManifest = async ({
   username,
   languageId,
   resourceId,
+  tag,
   ref,
   config,
   fullResponse,
   doRefFetch,
 }) => {
+  ref = ref || tag; // fallback to using tag if ref not given
   const repository = `${languageId}_${resourceId}`;
   const path = 'manifest.yaml';
   const response = await getFile({
@@ -206,9 +211,7 @@ export const getResourceProjectFile = async ({
 export const projectFromProjects = ({
   reference, projectId, projects,
 }) => {
-  const identifier = reference
-    ? reference?.projectId || reference?.bookId
-    : projectId;
+  const identifier = reference ? reference?.projectId || reference?.bookId : projectId;
   const project = projects.filter(
     (project) => project.identifier === identifier,
   )[0];

--- a/src/core/resources.js
+++ b/src/core/resources.js
@@ -211,7 +211,7 @@ export const getResourceProjectFile = async ({
 export const projectFromProjects = ({
   reference, projectId, projects,
 }) => {
-  const identifier = reference ? reference?.projectId || reference?.bookId : projectId;
+  const identifier = reference ? (reference?.projectId || reference?.bookId) : projectId;
   const project = projects.filter(
     (project) => project.identifier === identifier,
   )[0];

--- a/src/core/resources.js
+++ b/src/core/resources.js
@@ -96,14 +96,18 @@ export const parseResourceLink = ({
     // /api/v1/repos/ru_gl/ru_rlob/contents/manifest.yaml?ref=v0.9
     [, username, repository, , , ref] = matched;
     [languageId, resourceId] = repository.split('_');
-  } else if (resourceLink.includes('src/branch') || resourceLink.includes('src/tag')) {
+  } else if (resourceLink.includes('src/branch') ||
+    resourceLink.includes('src/tag') ||
+    resourceLink.includes('raw/branch') ||
+    resourceLink.includes('raw/tag')){
     //https://git.door43.org/ru_gl/ru_rlob/src/branch/master
     //https://git.door43.org/ru_gl/ru_rlob/src/tag/v1.1.1
+    //https://git.door43.org/ru_gl/ru_rlob/raw/tag/v1.1.1
     //https://git.door43.org/ru_gl/ru_rlob/src/branch/master/3jn
     parsedArray = resourceLink.match(
-      /https?:\/\/.*org\/([^/]*)\/([^/]*)\/src\/([^/]*)\/([^/]*)/
+      /https?:\/\/.*org\/([^/]*)\/([^/]*)\/([^/]*)\/([^/]*)\/([^/]*)/
     );
-    [, username, repository, , ref] = parsedArray;
+    [, username, repository, , , ref] = parsedArray;
     [languageId, resourceId] = repository.split('_');
   } else if (resourceLink.includes('http')) {
     //https://git.door43.org/ru_gl/ru_rlob

--- a/src/core/resources.js
+++ b/src/core/resources.js
@@ -96,8 +96,9 @@ export const parseResourceLink = ({
     // /api/v1/repos/ru_gl/ru_rlob/contents/manifest.yaml?ref=v0.9
     [, username, repository, , , ref] = matched;
     [languageId, resourceId] = repository.split('_');
-  } else if (resourceLink.includes('src/branch')) {
+  } else if (resourceLink.includes('src/branch') || resourceLink.includes('src/tag')) {
     //https://git.door43.org/ru_gl/ru_rlob/src/branch/master
+    //https://git.door43.org/ru_gl/ru_rlob/src/tag/v1.1.1
     //https://git.door43.org/ru_gl/ru_rlob/src/branch/master/3jn
     parsedArray = resourceLink.match(
       /https?:\/\/.*org\/([^/]*)\/([^/]*)\/src\/([^/]*)\/([^/]*)/

--- a/src/core/resources.spec.js
+++ b/src/core/resources.spec.js
@@ -145,8 +145,32 @@ describe('parseResourceLink without books', () => {
     expect(resource).toStrictEqual(resourceExpectedValue_);
   });
 
-  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/branch/master', () => {
-    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/branch/master`;
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/tag/v2.0.0', () => {
+    const resourceExpectedValue_ = {
+      ...resourceExpectedValue,
+      ref: `v2.0.0`,
+      resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
+    };
+    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/tag/v2.0.0`;
+    let resource = parseResourceLink({ resourceLink, config, reference });
+
+    expect(resource).toStrictEqual(resourceExpectedValue_);
+  });
+
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/raw/branch/other', () => {
+    const resourceExpectedValue_ = {
+      ...resourceExpectedValue,
+      ref: `v2.0.0`,
+      resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
+    };
+    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/raw/tag/v2.0.0`;
+    let resource = parseResourceLink({ resourceLink, config, reference });
+
+    expect(resource).toStrictEqual(resourceExpectedValue_);
+  });
+
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/raw/branch/master', () => {
+    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/raw/branch/master`;
     let resource = parseResourceLink({ resourceLink, config, reference });
 
     expect(resource).toStrictEqual(resourceExpectedValue);

--- a/src/core/resources.spec.js
+++ b/src/core/resources.spec.js
@@ -76,7 +76,7 @@ describe('resourceFromResourceLink- parse and download resource', () => {
 
   it('should be RLOB 2jn', async () => {
     const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
-    let content = await resourceFromResourceLink({ resourceLink, reference2jn, config });
+    let content = await resourceFromResourceLink({ resourceLink, reference: reference2jn, config });
     //console.log(content.projects[1]);
     expect(content.projects.length).toBeGreaterThan(0);
   })
@@ -208,10 +208,16 @@ describe('parseResourceLink with books', () => {
     });
 
     it('should be ru_rlob tag', () => {
+      const resourceExpectedValue_ = {
+        ...resourceExpectedValue,
+        ref: `v0.9`,
+        resourceLink: `ru_gl/ru/rlob/v0.9/3jn`,
+      };
+
       const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/tag/v0.9/3jn`;
       let resource = parseResourceLink({ resourceLink, config, reference });
 
-      expect(resource).toStrictEqual(resourceExpectedValue);
+      expect(resource).toStrictEqual(resourceExpectedValue_);
     });
 
     it('should be ru_rlob branch', () => {

--- a/src/core/resources.spec.js
+++ b/src/core/resources.spec.js
@@ -1,4 +1,10 @@
-import { parseResourceLink, extendProject, resourceFromResourceLink, getResourceManifest } from './resources'
+import {
+  parseResourceLink,
+  extendProject,
+  resourceFromResourceLink,
+  getResourceManifest,
+  getResponseData
+} from './resources';
 import { versesFromReferenceIdAndBooks, referenceIdFromReference } from '../components/parallel-scripture/helpers'
 import usfmJS from 'usfm-js';
 
@@ -15,7 +21,7 @@ const resourceExpectedValue = {
     "repository": "ru_rlob",
     "resourceId": "rlob",
     "resourceLink": "ru_gl/ru/rlob/master/3jn",
-    "tag": "master",
+    "ref": "master",
     "username": "ru_gl",
 }
 
@@ -53,40 +59,35 @@ describe('parse and download resource', () => {
 
         const resource = await resourceFromResourceLink({ resourceLink, reference, config });
         const file = await resource.project.file();
-        const book = await usfmJS.toJSON(file);
+        const book = await usfmJS.toJSON(getResponseData(file));
         //console.log(book.headers[0].content);
-        expect(book.headers[0].content).toContain("3JN RU_RLOB ru_Russian_ltr Unlocked Literal Bible");
+        expect(book.headers[0].content).toContain("3JN RU_RLOB ru_Русский_ltr Russian Literal Open Bible");
     })
-
 
     it('should be RLOB 2jn verses (empty)', async () => {
         const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
 
-        const resource = await resourceFromResourceLink({ resourceLink, reference2jn, config });
+        const resource = await resourceFromResourceLink({ resourceLink, reference: reference2jn, config });
         const file = await resource.project.file();
-        const book = await usfmJS.toJSON(file);
+        const book = await usfmJS.toJSON(getResponseData(file));
         //console.log(book.headers[0].content);
-        expect(book.headers[0].content).toContain("3JN RU_RLOB ru_Russian_ltr Unlocked Literal Bible");
+        expect(book.headers[0].content).toContain("2JN RU_RLOB ru_Русский_ltr");
     })
-})
 
-describe('parse and download resource', () => {
-    it('should be RLOB 2jn', async () => {
-        const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
-        let content = await resourceFromResourceLink({ resourceLink, reference2jn, config });
-        //console.log(content.projects[1]);
-        expect(content.projects.length).toBeGreaterThan(0);
-    })
+  it('should be RLOB 2jn', async () => {
+    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
+    let content = await resourceFromResourceLink({ resourceLink, reference2jn, config });
+    //console.log(content.projects[1]);
+    expect(content.projects.length).toBeGreaterThan(0);
+  })
 })
-
 
 describe('parseResourceLink without books', () => {
   it('should be ru_rlob from https://git.door43.org/api/v1/repos/ru_gl/ru_rlob/contents?ref=v0.9', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
-      tag: `v0.9`,
-      resourceLink: `ru_gl/ru/rlob/v0.9/3jn`,
-      versionFetch: true,
+      ref: `v0.9`,
+      resourceLink: `ru_gl/ru/rlob/v0.9/3jn`
     };
     const resourceLink = `https://git.door43.org/api/v1/repos/ru_gl/ru_rlob/contents?ref=v0.9`;
     let resource = parseResourceLink({ resourceLink, config, reference });
@@ -97,9 +98,8 @@ describe('parseResourceLink without books', () => {
   it('should be ru_rlob from /api/v1/repos/ru_gl/ru_rlob/contents?ref=v0.9', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
-      tag: `v0.9`,
+      ref: `v0.9`,
       resourceLink: `ru_gl/ru/rlob/v0.9/3jn`,
-      versionFetch: true,
     };
     const resourceLink = `/api/v1/repos/ru_gl/ru_rlob/contents?ref=v0.9`;
     let resource = parseResourceLink({ resourceLink, config, reference });
@@ -152,11 +152,18 @@ describe('parseResourceLink with books', () => {
         expect(resource).toStrictEqual(resourceExpectedValue);
     });
 
-    it('should be ru_rlob', () => {
-        const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/branch/master/3jn`;
-        let resource = parseResourceLink({ resourceLink, config, reference });
+    it('should be ru_rlob tag', () => {
+      const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/tag/v0.9/3jn`;
+      let resource = parseResourceLink({ resourceLink, config, reference });
 
-        expect(resource).toStrictEqual(resourceExpectedValue);
+      expect(resource).toStrictEqual(resourceExpectedValue);
+    });
+
+    it('should be ru_rlob branch', () => {
+      const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/branch/master/3jn`;
+      let resource = parseResourceLink({ resourceLink, config, reference });
+
+      expect(resource).toStrictEqual(resourceExpectedValue);
     });
 
     it('should be ru_rlob 1534', () => {

--- a/src/core/resources.spec.js
+++ b/src/core/resources.spec.js
@@ -25,7 +25,7 @@ const resourceExpectedValue = {
     "username": "ru_gl",
 }
 
-describe('parse and download resource', () => {
+describe('resourceFromResourceLink- parse and download resource', () => {
     it('should be RLOB 3jn', async () => {
         const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
         const book = await resourceFromResourceLink({ resourceLink, reference, config });
@@ -107,35 +107,66 @@ describe('parseResourceLink without books', () => {
     expect(resource).toStrictEqual(resourceExpectedValue_);
   });
 
-  it('should be ru_rlob', () => {
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob', () => {
     const resourceLink = `https://git.door43.org/ru_gl/ru_rlob`;
     let resource = parseResourceLink({ resourceLink, config, reference });
 
     expect(resource).toStrictEqual(resourceExpectedValue);
   });
 
-  it('should be ru_rlob', () => {
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/branch/master', () => {
     const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/branch/master`;
     let resource = parseResourceLink({ resourceLink, config, reference });
 
     expect(resource).toStrictEqual(resourceExpectedValue);
   });
 
-  it('should be ru_rlob', () => {
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/tag/v2.0.0', () => {
+    const resourceExpectedValue_ = {
+      ...resourceExpectedValue,
+      ref: `v2.0.0`,
+      resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
+    };
+    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/tag/v2.0.0`;
+    let resource = parseResourceLink({ resourceLink, config, reference });
+
+    expect(resource).toStrictEqual(resourceExpectedValue_);
+  });
+
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/branch/other', () => {
+    const resourceExpectedValue_ = {
+      ...resourceExpectedValue,
+      ref: `v2.0.0`,
+      resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
+    };
+    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/tag/v2.0.0`;
+    let resource = parseResourceLink({ resourceLink, config, reference });
+
+    expect(resource).toStrictEqual(resourceExpectedValue_);
+  });
+
+  it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/branch/master', () => {
+    const resourceLink = `https://git.door43.org/ru_gl/ru_rlob/src/branch/master`;
+    let resource = parseResourceLink({ resourceLink, config, reference });
+
+    expect(resource).toStrictEqual(resourceExpectedValue);
+  });
+
+  it('should be ru_rlob from /ru_gl/ru_rlob', () => {
     const resourceLink = `/ru_gl/ru_rlob`;
     let resource = parseResourceLink({ resourceLink, config, reference });
 
     expect(resource).toStrictEqual(resourceExpectedValue);
   });
 
-  it('should be ru_rlob', () => {
+  it('should be ru_rlob from ru_gl/ru_rlob', () => {
     const resourceLink = `ru_gl/ru_rlob`;
     let resource = parseResourceLink({ resourceLink, config, reference });
 
     expect(resource).toStrictEqual(resourceExpectedValue);
   });
 
-  it('should be ru_rlob', () => {
+  it('should be ru_rlob from ru_gl/ru/rlob/master/', () => {
     const resourceLink = `ru_gl/ru/rlob/master/`;
     let resource = parseResourceLink({ resourceLink, config, reference });
 

--- a/src/core/resources.spec.js
+++ b/src/core/resources.spec.js
@@ -21,6 +21,7 @@ const resourceExpectedValue = {
     "repository": "ru_rlob",
     "resourceId": "rlob",
     "resourceLink": "ru_gl/ru/rlob/master/3jn",
+    "tag": "master",
     "ref": "master",
     "username": "ru_gl",
 }
@@ -86,6 +87,7 @@ describe('parseResourceLink without books', () => {
   it('should be ru_rlob from https://git.door43.org/api/v1/repos/ru_gl/ru_rlob/contents?ref=v0.9', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
+      tag: `v0.9`,
       ref: `v0.9`,
       resourceLink: `ru_gl/ru/rlob/v0.9/3jn`
     };
@@ -98,6 +100,7 @@ describe('parseResourceLink without books', () => {
   it('should be ru_rlob from /api/v1/repos/ru_gl/ru_rlob/contents?ref=v0.9', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
+      tag: `v0.9`,
       ref: `v0.9`,
       resourceLink: `ru_gl/ru/rlob/v0.9/3jn`,
     };
@@ -124,6 +127,7 @@ describe('parseResourceLink without books', () => {
   it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/tag/v2.0.0', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
+      tag: `v2.0.0`,
       ref: `v2.0.0`,
       resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
     };
@@ -136,6 +140,7 @@ describe('parseResourceLink without books', () => {
   it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/branch/other', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
+      tag: `v2.0.0`,
       ref: `v2.0.0`,
       resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
     };
@@ -148,6 +153,7 @@ describe('parseResourceLink without books', () => {
   it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/src/tag/v2.0.0', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
+      tag: `v2.0.0`,
       ref: `v2.0.0`,
       resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
     };
@@ -160,6 +166,7 @@ describe('parseResourceLink without books', () => {
   it('should be ru_rlob from https://git.door43.org/ru_gl/ru_rlob/raw/branch/other', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,
+      tag: `v2.0.0`,
       ref: `v2.0.0`,
       resourceLink: `ru_gl/ru/rlob/v2.0.0/3jn`,
     };
@@ -210,6 +217,7 @@ describe('parseResourceLink with books', () => {
     it('should be ru_rlob tag', () => {
       const resourceExpectedValue_ = {
         ...resourceExpectedValue,
+        tag: `v0.9`,
         ref: `v0.9`,
         resourceLink: `ru_gl/ru/rlob/v0.9/3jn`,
       };


### PR DESCRIPTION
## Describe what your pull request addresses
part of https://github.com/unfoldingword/gateway-edit/issues/231
- [ ] fixed naming of unit tests so no name collisions
- [ ] added parsing of catalog next URLs

## Test Instructions
- test with https://deploy-preview-250--gateway-edit.netlify.app/

- [ ] login, use test_org/en and set book to **tit 1:1**
- [ ] on one of the scripture panes, set version source to: `https://git.door43.org/photonomad1/el-x-koine_ugnt/src/branch/photonomad1-patch-1` and should see loaded in pane:

<img width="459" alt="Screen Shot 2021-06-29 at 4 02 32 PM" src="https://user-images.githubusercontent.com/14238574/123862116-f392bf80-d8f5-11eb-9fb4-74a5de008044.png">

- [ ] on one of the scripture panes, set version source to: `https://git.door43.org/photonomad1/el-x-koine_ugnt/src/tag/tag-test` and should see loaded in pane:

<img width="477" alt="Screen Shot 2021-06-29 at 4 07 12 PM" src="https://user-images.githubusercontent.com/14238574/123860949-934f4e00-d8f4-11eb-86c9-f837108f0799.png">

- [ ] edit local storage and set `<user>_resource_card_tn_ref` to `photonomad1-patch-1`.  Reload page and the first tn article for 1:1 should show under Note: 

<img width="718" alt="Screen Shot 2021-06-29 at 4 14 06 PM" src="https://user-images.githubusercontent.com/14238574/123861448-2f795500-d8f5-11eb-9274-4b8839101a88.png">

- [ ] edit local storage and set `<user>_resource_card_ta_ref` to `photonomad1-patch-1`.  Reload page and with the first tn article for 1:1 selected, tA article should show: `More testing: Abstract nouns...`

<img width="673" alt="Screen Shot 2021-06-29 at 4 16 34 PM" src="https://user-images.githubusercontent.com/14238574/123862299-2dfc5c80-d8f6-11eb-81d1-a99e1e091777.png">

- [ ] edit local storage and set `<user>_resource_card_twl_ref` to `photonomad1-patch-1`.  Reload page and with 1:1, twl should show a second occurrence of Paul:

<img width="359" alt="Screen Shot 2021-06-29 at 4 23 39 PM" src="https://user-images.githubusercontent.com/14238574/123862535-7287f800-d8f6-11eb-8a12-b397173f4944.png">

- [ ] edit local storage and set `<user>_resource_card_twa_ref` to `photonomad1-patch-1`.  Reload page and with first Paul selected for 1:1, twa should show:

<img width="542" alt="Screen Shot 2021-06-29 at 4 24 58 PM" src="https://user-images.githubusercontent.com/14238574/123862678-a4995a00-d8f6-11eb-9865-fdaf0d4c6771.png">

- [ ] edit local storage and set `<user>_resource_card_tq_ref` to `photonomad1-patch-1`.  Reload page and for 1:1, tq should show:

<img width="536" alt="Screen Shot 2021-06-29 at 4 27 06 PM" src="https://user-images.githubusercontent.com/14238574/123863023-0c4fa500-d8f7-11eb-9b09-4906885247dd.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/111)
<!-- Reviewable:end -->
