### PR TITLE
Feature 228/add support for more urls

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,13 +3,20 @@ module.exports = {
   'plugins': [
     '@babel/plugin-proposal-nullish-coalescing-operator',
     '@babel/plugin-proposal-optional-chaining',
-    'inline-json-import',    [
-      'istanbul',
-      {
-        'include': ['src/**/**.js'],
-        'exclude': ['**/mocks/**'],
-      },
-    ],
+    'inline-json-import',
   ],
   'ignore': ['**/*.usfm.js'],
+  'env': {
+    'test': {
+      'plugins': [
+        [
+          'istanbul',
+          {
+            'include': ['src/**/**.js'],
+            'exclude': ['**/mocks/**'],
+          },
+        ],
+      ],
+    },
+  },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
+// default build config (used for everything but production)
 module.exports = {
   'presets': ['@babel/preset-env', '@babel/preset-react'],
   'plugins': [

--- a/babel.prod.config.js
+++ b/babel.prod.config.js
@@ -1,16 +1,10 @@
+// build config for production (on publish)
 module.exports = {
   'presets': ['@babel/preset-env', '@babel/preset-react'],
   'plugins': [
     '@babel/plugin-proposal-nullish-coalescing-operator',
     '@babel/plugin-proposal-optional-chaining',
     'inline-json-import',
-    [
-      'istanbul',
-      {
-        'include': ['src/**/**.js'],
-        'exclude': ['**/mocks/**'],
-      },
-    ],
   ],
   'ignore': ['**/*.usfm.js'],
 };

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "nyc:report": "nyc report --reporter=json-summary --reporter=text",
-    "test": "nyc start-test 6060 cypress:run && npm run nyc:report",
-    "test:unit": "jest",
+    "test": "set NODE_ENV=test&& nyc start-test 6060 cypress:run && npm run nyc:report",
+    "test:unit": "set NODE_ENV=test&& jest",
     "create-coverage-badge": "bash scripts/create-badge-json.sh"
   },
   "eslintConfig": {
@@ -115,7 +115,8 @@
       "!**/vendor/**"
     ],
     "testMatch": [
-      "<rootDir>**/**.spec.js"
+      "<rootDir>/src/**/**.spec.js",
+      "<rootDir>/__tests__/**/**.spec.js"
     ],
     "testPathIgnorePatterns": [
       "node_modules",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "5.1.0",
+  "version": "5.1.1-alpha.3",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "start": "styleguidist server",
     "build": "styleguidist build",
     "deploy": "git push",
-    "prepublishOnly": "rm -fr ./dist && babel ./src --out-dir ./dist -s inline",
+    "prepublishOnly": "rm -fr ./dist && babel --config-file ./babel.prod.config.js ./src --out-dir ./dist -s inline",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "nyc:report": "nyc report --reporter=json-summary --reporter=text",
-    "test": "set NODE_ENV=test&& nyc start-test 6060 cypress:run && npm run nyc:report",
-    "test:unit": "set NODE_ENV=test&& jest",
+    "test": "nyc start-test 6060 cypress:run && npm run nyc:report",
+    "test:unit": "jest",
     "create-coverage-badge": "bash scripts/create-badge-json.sh"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "5.1.1-alpha.3",
+  "version": "5.1.1",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/src/core/resources.js
+++ b/src/core/resources.js
@@ -61,13 +61,11 @@ export const resourceFromResourceLink = async ({
     };
     return _resource;
   } catch (e) {
-    console.log(e);
     const errorMessage =
       'scripture-resources-rcl: resources.js: Cannot load resource [' +
       resourceLink +
       ']';
-    console.error(errorMessage);
-    console.error(e);
+    console.error(errorMessage, e);
     return { manifestHttpResponse };
   }
 };
@@ -277,8 +275,12 @@ export const extendProject = ({
  */
 export function getResponseData(response) {
   let data = response?.data;
-  data = (data?.encoding === 'base64') ? decodeBase64ToUtf8(data.content) : data;
-  return data;
+
+  if (!data?.errors) { // make sure was not a fetch error
+    data = (data?.encoding === 'base64') ? decodeBase64ToUtf8(data.content) : data;
+    return data;
+  }
+  return null;
 }
 
 export const parseBook = async ({ project }) => {

--- a/src/core/resources.js
+++ b/src/core/resources.js
@@ -98,6 +98,15 @@ export const parseResourceLink = ({
     // /api/v1/repos/ru_gl/ru_rlob/contents/manifest.yaml?ref=v0.9
     [, username, repository, , , ref] = matched;
     [languageId, resourceId] = repository.split('_');
+  } else if (matched = resourceLink.match(/https?:\/\/.*org\/([^/]*)\/([^/]*).git/)) {
+    // https://git.door43.org/Door43-Catalog/en_ust.git
+    [, username, repository] = matched;
+    [languageId, resourceId] = repository.split('_');
+  } else if (resourceLink.includes('/u/')) {
+    // https://door43.org/u/unfoldingWord/en_ult/
+    parsedArray = resourceLink.match(/https?:\/\/.*org\/u\/([^/]*)\/([^/]*)/);
+    [, username, repository] = parsedArray;
+    [languageId, resourceId] = repository.split('_');
   } else if (resourceLink.includes('src/branch') ||
     resourceLink.includes('src/tag') ||
     resourceLink.includes('raw/branch') ||

--- a/src/core/resources.spec.js
+++ b/src/core/resources.spec.js
@@ -84,6 +84,36 @@ describe('resourceFromResourceLink- parse and download resource', () => {
 })
 
 describe('parseResourceLink without books', () => {
+  it('should be en_ult from https://git.door43.org/Door43-Catalog/en_ust.git', () => {
+    const resourceExpectedValue_ = {
+      ...resourceExpectedValue,
+      languageId: 'en',
+      repository: 'en_ult',
+      resourceId: 'ult',
+      username: 'unfoldingWord',
+      resourceLink: `unfoldingWord/en/ult/master/3jn`,
+    };
+    const resourceLink = `https://door43.org/u/unfoldingWord/en_ult/`;
+    let resource = parseResourceLink({ resourceLink, config, reference });
+
+    expect(resource).toStrictEqual(resourceExpectedValue_);
+  });
+
+  it('should be en_ult from https://door43.org/u/unfoldingWord/en_ult/', () => {
+    const resourceExpectedValue_ = {
+      ...resourceExpectedValue,
+      languageId: 'en',
+      repository: 'en_ult',
+      resourceId: 'ult',
+      username: 'unfoldingWord',
+      resourceLink: `unfoldingWord/en/ult/master/3jn`,
+    };
+    const resourceLink = `https://door43.org/u/unfoldingWord/en_ult/`;
+    let resource = parseResourceLink({ resourceLink, config, reference });
+
+    expect(resource).toStrictEqual(resourceExpectedValue_);
+  });
+
   it('should be ru_rlob from https://git.door43.org/api/v1/repos/ru_gl/ru_rlob/contents?ref=v0.9', () => {
     const resourceExpectedValue_ = {
       ...resourceExpectedValue,


### PR DESCRIPTION
## Describe what your pull request addresses
part of https://github.com/unfoldingword/gateway-edit/issues/228
- [ ] added support for more URL formats

## Test Instructions
- test with https://deploy-preview-265--gateway-edit.netlify.app/
- try add the following scripture urls to a scripture pane.  Make sure scripture actually shows up in scripture pane:
- [ ] `https://git.door43.org/unfoldingWord/en_ult`
- [ ] `https://git.door43.org/unfoldingWord/el-x-koine_ugnt/src/tag/v0.20`
- [ ] `https://door43.org/u/unfoldingWord/en_ult/`
- [ ] `https://git.door43.org/Door43-Catalog/en_ust.git`
- [ ] `git@git.door43.org:unfoldingWord/en_ult.git`
- [ ] change bible reference to heb
- [ ] change a scripture pane to `https://git.door43.org/ru_gl/ru_rsob` and should see message that `This book can not be found in the project...`.  Should not get a crash
- [ ] switch book to tit and should see Russian content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/scripture-resources-rcl/116)
<!-- Reviewable:end -->
