### PR TITLE
Fix highlights by populating VerseObjects if resource has new format

### DIFF
--- a/src/components/parallel-scripture/ScriptureTable.js
+++ b/src/components/parallel-scripture/ScriptureTable.js
@@ -48,10 +48,12 @@ function ScriptureTable({
     reference &&
     reference.verse &&
     books[0] &&
-    books[0].chapters &&
-    books[0].chapters[reference.chapter]
+  ((books[0].chapters &&
+		books[0].chapters[reference.chapter]) ||
+  ((books[0].json.chapters &&
+	    books[0].json.chapters[reference.chapter]) ))
   ) {
-    const chapter = books[0].chapters[reference.chapter];
+    const chapter = books[0].json ? books[0].json.chapters[reference.chapter] : books[0].chapters[reference.chapter];
     const verse = chapter[reference.verse];
     verseObjects = verse ? verse.verseObjects : [];
   }


### PR DESCRIPTION
## Describe what your pull request addresses
Highlighting of quotes stopped working. 

## Test Instructions

- Checkout branch and start styleguidist parallel scripture page http://localhost:6060/#/Parallel%20Scripture%20?id=parallelscripture
- Enter 1,2 or 3 in the Occurrence text box above the first parallel scriptures table. 
- " καὶ μὴ" and "But not" and the rest should be highlighted yellow. 
