### PR TITLE
added support for verse spans

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "bible-reference-range": "^1.0.1",
+    "bible-reference-range": "^1.1.0",
     "deep-freeze": "^0.0.1",
     "gitea-react-toolkit": "2.2.1",
     "js-yaml-parser": "^1.0.0",
@@ -47,7 +47,7 @@
     "string-punctuation-tokenizer": "2.1.2",
     "tc-ui-toolkit": "^5.3.3",
     "use-deep-compare-effect": "^1.3.1",
-    "usfm-js": "3.4.0",
+    "usfm-js": "^3.4.2",
     "uw-quote-helpers": "^1.0.0",
     "word-aligner": "^1.0.0", 
     "xregexp": "^4.1.1"

--- a/src/components/selections/helpers.js
+++ b/src/components/selections/helpers.js
@@ -2,6 +2,7 @@ import {
   selectionsFromQuoteAndVerseObjects,
   normalizeString,
 } from "../../core/selections/selections";
+import { doesReferenceContain } from "bible-reference-range";
 
 // const stringify = (array) => array.map(object => JSON.stringify(object));
 //export const parsify = (array) => array.map(string => JSON.parse(string));
@@ -80,8 +81,14 @@ export const isSelected = ({ word, selections, ref }) => {
 };
 
 export const areSelected = ({ words, selections, ref }) => {
-  const highlights = selections.get(ref)
-  if (!highlights) return false;
+  let highlights = [];
+
+  for (let [currentRef, selection] of selections) { 
+    const containsReference = doesReferenceContain(ref, currentRef);
+    if (containsReference) highlights = highlights.concat(selection);
+  }
+
+  if (!highlights.length) return false;
   let selected = false;
   const _selections = words.map((word) => selectionFromWord(word));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16696,10 +16696,10 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-usfm-js@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/usfm-js/-/usfm-js-3.4.0.tgz#d3a00634b7219163b2bf41dc9dd83d976ec7ef26"
-  integrity sha512-8pCtMxzb/E3/4PPLLpf9KK10vza1I1/4tZJaDhJ+ycTGfg5JfT6GmDTxYFd6Nw81sbS0CVoyyG89a5ff6yHCzA==
+usfm-js@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/usfm-js/-/usfm-js-3.4.2.tgz#a4232cffe38c9f521246b007a4045648cbcf419a"
+  integrity sha512-i5nGxGwFhkOWd7xgfVWQ6GTkCpksfy5AUIwNJcwanTn3ua5J1nwl3pjApCDA6x1B++8ICkcQMUt0FB/bkKdE2g==
   dependencies:
     lodash.clonedeep "^4.5.0"
 


### PR DESCRIPTION
## Describe what your pull request addresses

- Added support for verse spans, which were not being highlighted as found in tCC (https://github.com/unfoldingWord/tc-create-app/issues/1587)

## Test Instructions

- Use the playground section in the deploy preview (https://deploy-preview-170--scripture-resources-rcl.netlify.app/#/Parallel%20Scripture%20?id=parallelscripture) to test this using this data:
    - book: deu
    - lang: hebrew (ot)
    - chapter: 1
    - verse: 35
    - quote: לַ⁠אֲבֹתֵי⁠כֶֽם׃
    - occurrence: -1
    
- Text in UST should be a verse span  (1:35-36) and it should be highlighted


