### PR TITLE
Catch update selections errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",

--- a/src/components/selections/useSelections.js
+++ b/src/components/selections/useSelections.js
@@ -16,14 +16,18 @@ function useSelections({
 }) {
 
   useDeepCompareEffectNoCheck(() => {
-    const _selections = bookObject ? getQuoteMatchesInBookRef({
-      quote,
-      ref: refString,
-      bookObject,
-      occurrence: currentOccurrenceValue,
-      isOrigLang: true
-    }) : [];
-    update(_selections)
+    try {
+      const _selections = bookObject ? getQuoteMatchesInBookRef({
+        quote,
+        ref: refString,
+        bookObject,
+        occurrence: currentOccurrenceValue,
+        isOrigLang: true
+      }) : [];
+      update(_selections)
+    } catch (error) {
+      console.error(`Selections broken:\n`, error);
+    }
   }, [quote, currentOccurrenceValue, bookObject]);
 
   useDeepCompareEffectNoCheck(() => {


### PR DESCRIPTION
## Describe what your pull request addresses

This aims to solve issue (https://github.com/unfoldingWord/tc-create-app/issues/1596) by preventing the app from crashing.

- [ ] An error while trying to find selections  should not break apps but rather inform the consumer what broke the highlighting feature.

## Test Instructions

- [ ] Open the example for ParallelScripture  (https://deploy-preview-171--scripture-resources-rcl.netlify.app/#/Parallel%20Scripture%20?id=parallelscripture)
- [ ] Pass it an undefined quote by changing the example code (`defaultQuote = undefined`).
- [ ] Text should not be highlighted and an error should be logged to console.

## Before merging

- [ ] Check version has been increased relative to npm's (https://www.npmjs.com/package/scripture-resources-rcl)
- [ ] Publish to npm