### PR TITLE
Fix greek elision highlight error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripture-resources-rcl",
   "description": "A React Component Library for Rendering Scripture Resources.",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "homepage": "https://scripture-resources-rcl.netlify.com/",
   "repository": {
     "type": "git",
@@ -18,8 +18,8 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "nyc:report": "nyc report --reporter=json-summary --reporter=text",
-    "test": "nyc start-test 6060 cypress:run && npm run nyc:report",
-    "test:unit": "jest",
+    "test": "jest",
+    "test:e2e": "nyc start-test 6060 cypress:run && npm run nyc:report",
     "create-coverage-badge": "bash scripts/create-badge-json.sh"
   },
   "eslintConfig": {

--- a/src/components/parallel-scripture/ParallelScripture.md
+++ b/src/components/parallel-scripture/ParallelScripture.md
@@ -99,11 +99,11 @@ import {
 
 // DEFAULT VALUES
 const defaults = {
-  bookId: "tit",
+  bookId: "mat",
   lang: "nt", //ot or nt
-  chapter: "1",
-  verse: "3",
-  quote: "ἐφανέρωσεν & τὸν λόγον αὐτοῦ",
+  chapter: "12",
+  verse: "25",
+  quote: "πᾶσα βασιλεία μερισθεῖσα καθ’ ἑαυτῆς ἐρημοῦται, καὶ πᾶσα πόλις ἢ οἰκία μερισθεῖσα καθ’ ἑαυτῆς οὐ σταθήσεται",
   occurrence: -1
 }
 

--- a/src/components/selections/helpers.spec.js
+++ b/src/components/selections/helpers.spec.js
@@ -1,0 +1,87 @@
+import { areSelected } from "./helpers";
+
+describe("selectionsFromQuoteAndString", () => {
+  it("should select text with greek's elision marks", () => {
+    const ref = "12:25"
+    const selected = areSelected({
+      ref,
+      words: [
+        {
+          "strong": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,G,,,",
+          "occurrence": "1",
+          "occurrences": "2",
+          "content": "καθ’"
+        }
+      ],
+      selections: new Map([[ref, [
+        {
+          "text": "πᾶσα",
+          "occurrence": 1
+        },
+        {
+          "text": "βασιλεία",
+          "occurrence": 1
+        },
+        {
+          "text": "μερισθεῖσα",
+          "occurrence": 1
+        },
+        {
+          "text": "καθ",
+          "occurrence": 1
+        },
+        {
+          "text": "ἑαυτῆς",
+          "occurrence": 1
+        },
+        {
+          "text": "ἐρημοῦται",
+          "occurrence": 1
+        },
+        {
+          "text": "καὶ",
+          "occurrence": 1
+        },
+        {
+          "text": "πᾶσα",
+          "occurrence": 2
+        },
+        {
+          "text": "πόλις",
+          "occurrence": 1
+        },
+        {
+          "text": "ἢ",
+          "occurrence": 1
+        },
+        {
+          "text": "οἰκία",
+          "occurrence": 1
+        },
+        {
+          "text": "μερισθεῖσα",
+          "occurrence": 2
+        },
+        {
+          "text": "καθ",
+          "occurrence": 2
+        },
+        {
+          "text": "ἑαυτῆς",
+          "occurrence": 2
+        },
+        {
+          "text": "οὐ",
+          "occurrence": 1
+        },
+        {
+          "text": "σταθήσεται",
+          "occurrence": 1
+        }
+      ]]])
+    })
+    expect(selected).toBe(true);
+  });
+})

--- a/src/core/selections/selections.js
+++ b/src/core/selections/selections.js
@@ -574,7 +574,7 @@ export const occurrencesInString = (stringMap, subString) => {
 const tokenizer = (text) => {
   return tokenize({
     text: text,
-    greedy: true,
+    includePunctuation: false,
     normalize: true,
   });
 };


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] This  Fixes #179, by making the normalizer non greedy as it is for uw-quote-helpers normalizer.

## Test Instructions

- [ ] The case described in issue #179 is replicated in the playground for ParallelScripture component in the styleguidist.
- [ ] A unit test has been added to the areSelected function to make sure it selects words with elision marker.
